### PR TITLE
feat: adding more specific quota errors, and test coverage for the package

### DIFF
--- a/pkg/errors/armerrors.go
+++ b/pkg/errors/armerrors.go
@@ -44,13 +44,20 @@ func ZonalAllocationFailureOccurred(err error) bool {
 	return azErr != nil && azErr.ErrorCode == ZoneAllocationFailed
 }
 
+// SKUFamilyQuotaHasBeenReached tells us if we have exceeded our Quota.
+func SKUFamilyQuotaHasBeenReached(err error) bool {
+	azErr := IsResponseError(err)
+	return azErr != nil && azErr.ErrorCode == OperationNotAllowed && strings.Contains(azErr.Error(), SKUFamilyQuotaExceededTerm)
+}
+
 // SubscriptionQuotaHasBeenReached tells us if we have exceeded our Quota.
 func SubscriptionQuotaHasBeenReached(err error) bool {
 	azErr := IsResponseError(err)
 	return azErr != nil && azErr.ErrorCode == OperationNotAllowed && strings.Contains(azErr.Error(), SubscriptionQuotaExceededTerm)
 }
 
-// RegionalQuotaHasBeenReached communicates if we have reached the quota for a given region.
+
+// RegionalQuotaHasBeenReached communicates if we have reached the quota limit for a given region under a specific subscription
 func RegionalQuotaHasBeenReached(err error) bool {
 	azErr := IsResponseError(err)
 	return azErr != nil && azErr.ErrorCode == OperationNotAllowed && strings.Contains(azErr.Error(), RegionalQuotaExceededTerm)

--- a/pkg/errors/armerrors_test.go
+++ b/pkg/errors/armerrors_test.go
@@ -1,30 +1,21 @@
 package errors
 
-
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"testing"
+        "bytes"
+	"io"
+	"net/http"
 
-    "bytes"
-    "io"
-    "net/http"
-
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsNotFoundErr(t *testing.T) {
 	err1 := &azcore.ResponseError{ErrorCode: ResourceNotFound}
-	if !IsNotFoundErr(err1) {
-		t.Errorf("Expected IsNotFoundErr to return true for err1, but it returned false")
-	}
-
+	assert.Equal(t, IsNotFoundErr(err1), true)
 	err2 := &azcore.ResponseError{ErrorCode: "SomeOtherErrorCode"}
-	if IsNotFoundErr(err2) {
-		t.Errorf("Expected IsNotFoundErr to return false for err2, but it returned true")
-	}
-
-	if IsNotFoundErr(nil) {
-		t.Errorf("Expected IsNotFoundErr to return false for nil input, but it returned true")
-	}
+        assert.Equal(t, IsNotFoundErr(err2), false)
+	assert.Equal(t, IsNotFoundErr(nil), false)
 }
 
 
@@ -64,7 +55,7 @@ func TestSKUFamilyQuotaHasBeenReached(t *testing.T) {
     for _, tc := range testCases {
         t.Run(tc.description, func(t *testing.T) {
             if got := SKUFamilyQuotaHasBeenReached(tc.responseError); got != tc.expected {
-                t.Errorf("SKUFamilyQuotaHasBeenReached() = %v, want %v", got, tc.expected)
+                t.Errorf("SKUFamilyQuotaHasBeenReached() = %t, want %t", got, tc.expected)
             }
         })
     }
@@ -100,7 +91,7 @@ func TestZonalAllocationFailureOccurred(t *testing.T) {
     for _, tc := range testCases {
         t.Run(tc.description, func(t *testing.T) {
             if got := ZonalAllocationFailureOccurred(tc.responseError); got != tc.expected {
-                t.Errorf("ZonalAllocationFailureOccurred() = %v, want %v for %s", got, tc.expected, tc.description)
+                t.Errorf("ZonalAllocationFailureOccurred() = %t, want %t for %s", got, tc.expected, tc.description)
             }
         })
     }
@@ -138,7 +129,7 @@ func TestRegionalQuotaHasBeenReached(t *testing.T) {
     for _, tc := range testCases {
         t.Run(tc.description, func(t *testing.T) {
             if got := RegionalQuotaHasBeenReached(tc.responseError); got != tc.expected {
-                t.Errorf("RegionalQuotaHasBeenReached() = %v, want %v for %s", got, tc.expected, tc.description)
+                t.Errorf("RegionalQuotaHasBeenReached() = %t, want %t for %s", got, tc.expected, tc.description)
             }
         })
     }

--- a/pkg/errors/armerrors_test.go
+++ b/pkg/errors/armerrors_test.go
@@ -1,0 +1,146 @@
+package errors
+
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"testing"
+
+    "bytes"
+    "io"
+    "net/http"
+
+)
+
+func TestIsNotFoundErr(t *testing.T) {
+	err1 := &azcore.ResponseError{ErrorCode: ResourceNotFound}
+	if !IsNotFoundErr(err1) {
+		t.Errorf("Expected IsNotFoundErr to return true for err1, but it returned false")
+	}
+
+	err2 := &azcore.ResponseError{ErrorCode: "SomeOtherErrorCode"}
+	if IsNotFoundErr(err2) {
+		t.Errorf("Expected IsNotFoundErr to return false for err2, but it returned true")
+	}
+
+	if IsNotFoundErr(nil) {
+		t.Errorf("Expected IsNotFoundErr to return false for nil input, but it returned true")
+	}
+}
+
+
+
+type testCase struct {
+    description        string
+    responseError      *azcore.ResponseError
+    expected bool
+}
+
+func TestSubscriptionQuotaHasBeenReached(t *testing.T) {
+    testCases := []testCase{
+        {
+            description: "Quota Exceeded",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   "OperationNotAllowed",
+                StatusCode: http.StatusForbidden,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "OperationNotAllowed", "message": "Family Cores quota exceeded"}}`))),
+                },
+            },
+            expected: true,
+        },
+        {
+            description: "Different Error Code",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   "ResourceNotFound",
+                StatusCode: http.StatusNotFound,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "ResourceNotFound"}}`))),
+                },
+            },
+            expected: false,
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.description, func(t *testing.T) {
+            if got := SubscriptionQuotaHasBeenReached(tc.responseError); got != tc.expected {
+                t.Errorf("SubscriptionQuotaHasBeenReached() = %v, want %v", got, tc.expected)
+            }
+        })
+    }
+}
+
+
+func TestZonalAllocationFailureOccurred(t *testing.T) {
+    testCases := []testCase{
+        {
+            description: "Zonal Allocation Failed",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   ZoneAllocationFailed,
+                StatusCode: http.StatusBadRequest,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "ZonalAllocationFailed", "message": "Failed to allocate resources in the zone"}}`))),
+                },
+            },
+            expected: true,
+        },
+        {
+            description: "Different Error Code",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   "ResourceNotFound",
+                StatusCode: http.StatusNotFound,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "ResourceNotFound"}}`))),
+                },
+            },
+            expected: false,
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.description, func(t *testing.T) {
+            if got := ZonalAllocationFailureOccurred(tc.responseError); got != tc.expected {
+                t.Errorf("ZonalAllocationFailureOccurred() = %v, want %v for %s", got, tc.expected, tc.description)
+            }
+        })
+    }
+}
+
+
+
+
+func TestRegionalQuotaHasBeenReached(t *testing.T) {
+    testCases := []testCase{
+        {
+            description: "Regional Quota Exceeded",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   OperationNotAllowed,
+                StatusCode: http.StatusForbidden,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "OperationNotAllowed", "message": "exceeding approved Total Regional Cores quota"}}`))),
+                },
+            },
+            expected: true,
+        },
+        {
+            description: "Different Error Code",
+            responseError: &azcore.ResponseError{
+                ErrorCode:   "ResourceNotFound",
+                StatusCode: http.StatusNotFound,
+                RawResponse: &http.Response{
+                    Body: io.NopCloser(bytes.NewReader([]byte(`{"error": {"code": "ResourceNotFound"}}`))),
+                },
+            },
+            expected: false,
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.description, func(t *testing.T) {
+            if got := RegionalQuotaHasBeenReached(tc.responseError); got != tc.expected {
+                t.Errorf("RegionalQuotaHasBeenReached() = %v, want %v for %s", got, tc.expected, tc.description)
+            }
+        })
+    }
+}
+

--- a/pkg/errors/armerrors_test.go
+++ b/pkg/errors/armerrors_test.go
@@ -35,7 +35,7 @@ type testCase struct {
     expected bool
 }
 
-func TestSubscriptionQuotaHasBeenReached(t *testing.T) {
+func TestSKUFamilyQuotaHasBeenReached(t *testing.T) {
     testCases := []testCase{
         {
             description: "Quota Exceeded",
@@ -63,8 +63,8 @@ func TestSubscriptionQuotaHasBeenReached(t *testing.T) {
 
     for _, tc := range testCases {
         t.Run(tc.description, func(t *testing.T) {
-            if got := SubscriptionQuotaHasBeenReached(tc.responseError); got != tc.expected {
-                t.Errorf("SubscriptionQuotaHasBeenReached() = %v, want %v", got, tc.expected)
+            if got := SKUFamilyQuotaHasBeenReached(tc.responseError); got != tc.expected {
+                t.Errorf("SKUFamilyQuotaHasBeenReached() = %v, want %v", got, tc.expected)
             }
         })
     }

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -8,6 +8,8 @@ const (
 	ZoneAllocationFailed = "ZonalAllocationFailed"
 
 	// Error search terms
-	SubscriptionQuotaExceededTerm = "Family Cores quota"
+	SKUFamilyQuotaExceededTerm = "Family Cores quota"
+	SubscriptionQuotaExceededTerm = "Submit a request for Quota increase"
+
 	RegionalQuotaExceededTerm     = "exceeding approved Total Regional Cores quota"
 )

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -8,6 +8,6 @@ const (
 	ZoneAllocationFailed = "ZonalAllocationFailed"
 
 	// Error search terms
-	SubscriptionQuotaExceededTerm = "Submit a request for Quota increase"
+	SubscriptionQuotaExceededTerm = "Family Cores quota"
 	RegionalQuotaExceededTerm     = "exceeding approved Total Regional Cores quota"
 )

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -10,6 +10,5 @@ const (
 	// Error search terms
 	SKUFamilyQuotaExceededTerm = "Family Cores quota"
 	SubscriptionQuotaExceededTerm = "Submit a request for Quota increase"
-
 	RegionalQuotaExceededTerm     = "exceeding approved Total Regional Cores quota"
 )


### PR DESCRIPTION
**What this PR Does**
Subscription Level Quota captures the fact there is a quota error well, but we need more specific quota errors inside of karpenter. 

The behavior should differ between TotalRegionalCores subscription level quota, and between a SKU Families quota error. 


So now I want to detect them separately. 


**How was this PR Tested** 
Unit tests