### PR TITLE
feat: deprecate go-armbalancer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
-	github.com/Azure/go-armbalancer v0.0.3
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontai
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0/go.mod h1:U5gpsREQZE6SLk1t/cFfc1eMhYAlYpEzvaYXuDfefy8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
-github.com/Azure/go-armbalancer v0.0.3 h1:jihdq+YpyopBpt3grk/nTYNcaj/9XnmQD3vfcJaeEAg=
-github.com/Azure/go-armbalancer v0.0.3/go.mod h1:yTg7MA/8YnfKQc9o97tzAJ7fbdVkod1xGsIvKmhYPRE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/middleware/default_http_client.go
+++ b/pkg/middleware/default_http_client.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/go-armbalancer"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/net/http2"
@@ -34,8 +33,7 @@ var (
 	defaultRoundTripper http.RoundTripper
 )
 
-// DefaultHTTPClient returns a shared http client, and transport leveraging armbalancer for
-// clientside loadbalancing, so we can leverage HTTP/2, and not get throttled by arm at the instance level.
+// DefaultHTTPClient returns a shared http client
 func DefaultHTTPClient() *http.Client {
 	return defaultHTTPClient
 }
@@ -60,14 +58,7 @@ func init() {
 	// azure sdk related issue is here:
 	// https://github.com/Azure/azure-sdk-for-go/issues/21346#issuecomment-1699665586
 	configureHttp2TransportPing(defaultTransport)
-	defaultRoundTripper = armbalancer.New(armbalancer.Options{
-		// PoolSize is the number of clientside http/2 persistent connections
-		// we want to have configured in our transport. Note, that without clientside loadbalancing
-		// with arm, HTTP/2 Will force persistent connection to stick to a single arm instance, and will
-		// result in a substantial amount of throttling
-		PoolSize:  100,
-		Transport: defaultTransport,
-	})
+	defaultRoundTripper = defaultTransport
 
 	defaultHTTPClient = &http.Client{
 		Transport: otelhttp.NewTransport(


### PR DESCRIPTION
Arm is using a new throttling limit are applied per region rather than per instance of Azure Resource Manager, so we can deprecate armlbalancer.