### PR TITLE
chore: have actions/setup-go use version from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: 1.19
+        go-version-file: go.mod
+        check-latest: true
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Paves the way for updating Go version