### PR TITLE
fix: not found should work for any RP

### DIFF
--- a/pkg/errors/armerrors.go
+++ b/pkg/errors/armerrors.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -34,7 +35,7 @@ func IsResponseError(err error) *azcore.ResponseError {
 // IsNotFoundErr is used to determine if we are failing to find a resource within azure.
 func IsNotFoundErr(err error) bool {
 	azErr := IsResponseError(err)
-	return azErr != nil && azErr.ErrorCode == ResourceNotFound
+	return azErr != nil && azErr.StatusCode == http.StatusNotFound
 }
 
 // ZonalAllocationFailureOccurred communicates if we have failed to allocate a resource in a zone, and should try another zone.

--- a/pkg/errors/armerrors_test.go
+++ b/pkg/errors/armerrors_test.go
@@ -64,10 +64,14 @@ func checkErrors(t *testing.T, testName string, testCases []testCase, testFunc e
 
 // Basic Response Error Tests
 func TestIsNotFoundErr(t *testing.T) {
-	err1 := &azcore.ResponseError{ErrorCode: ResourceNotFound}
+	err1 := &azcore.ResponseError{StatusCode: http.StatusNotFound}
 	assert.Equal(t, IsNotFoundErr(err1), true)
-	err2 := &azcore.ResponseError{ErrorCode: "SomeOtherErrorCode"}
+	err2 := &azcore.ResponseError{StatusCode: http.StatusOK}
 	assert.Equal(t, IsNotFoundErr(err2), false)
+	err3 := &azcore.ResponseError{StatusCode: http.StatusBadRequest}
+	assert.Equal(t, IsNotFoundErr(err3), false)
+	err4 := &azcore.ResponseError{StatusCode: http.StatusInternalServerError}
+	assert.Equal(t, IsNotFoundErr(err4), false)
 	assert.Equal(t, IsNotFoundErr(nil), false)
 }
 

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -3,7 +3,6 @@ package errors
 const (
 
 	// Error codes
-	ResourceNotFound                      = "ResourceNotFound"
 	OperationNotAllowed                   = "OperationNotAllowed"
 	AllocationFailed                      = "AllocationFailed"
 	OverconstrainedAllocationRequest      = "OverconstrainedAllocationRequest"


### PR DESCRIPTION
When working on introducing a new project that validates the existence of a subnet, diving into the not found error codes for 


1. ResourceGroup 
2. NetworkInterface 
3. VNET 
4. Subnet 


I found that ResourceGroup + Subnet both do not return `ResourceNotFound`. Subnet returns just `NotFound` and resource group returns `ResourceGroupNotFound`. 


But all of them return 404. I am changing the library to more simply check the error code rather than the status code. 