### PR TITLE
Add first response byte connection tracking

### DIFF
--- a/pkg/middleware/arm_error_collector.go
+++ b/pkg/middleware/arm_error_collector.go
@@ -193,11 +193,15 @@ func addConnectionTracingToRequestContext(ctx context.Context, connTracking *Htt
 	trace := &httptrace.ClientTrace{
 		GotFirstResponseByte: func() {
 			traceVars.mu.RLock()
-			gotConn := traceVars.gotConn
+			var firstByteTimeInMs int64
+			gotConnRecorded := traceVars.gotConn != nil
+			if gotConnRecorded {
+				firstByteTimeInMs = time.Since(*traceVars.gotConn).Milliseconds()
+			}
 			traceVars.mu.RUnlock()
 
-			if gotConn != nil {
-				connTracking.setFirstByteTimeInMs(time.Since(*gotConn).Milliseconds())
+			if gotConnRecorded {
+				connTracking.setFirstByteTimeInMs(firstByteTimeInMs)
 			}
 		},
 		GetConn: func(hostPort string) {

--- a/pkg/middleware/arm_error_collector.go
+++ b/pkg/middleware/arm_error_collector.go
@@ -179,12 +179,12 @@ func parseTransportError(err error) *ArmError {
 }
 
 func addConnectionTracingToRequestContext(ctx context.Context, connTracking *HttpConnTracking) context.Context {
-	requestStart := time.Now()
 	// traceVars holds timing variables that need to be protected from concurrent access
 	// since HTTP trace callbacks run in separate goroutines
 	traceVars := &struct {
 		mu        sync.RWMutex
 		getConn   *time.Time
+		gotConn   *time.Time
 		dnsStart  *time.Time
 		connStart *time.Time
 		tlsStart  *time.Time
@@ -192,7 +192,13 @@ func addConnectionTracingToRequestContext(ctx context.Context, connTracking *Htt
 
 	trace := &httptrace.ClientTrace{
 		GotFirstResponseByte: func() {
-			connTracking.setFirstByteTimeInMs(time.Since(requestStart).Milliseconds())
+			traceVars.mu.RLock()
+			gotConn := traceVars.gotConn
+			traceVars.mu.RUnlock()
+
+			if gotConn != nil {
+				connTracking.setFirstByteTimeInMs(time.Since(*gotConn).Milliseconds())
+			}
 		},
 		GetConn: func(hostPort string) {
 			traceVars.mu.Lock()
@@ -200,12 +206,14 @@ func addConnectionTracingToRequestContext(ctx context.Context, connTracking *Htt
 			traceVars.getConn = to.Ptr(time.Now())
 		},
 		GotConn: func(connInfo httptrace.GotConnInfo) {
-			traceVars.mu.RLock()
+			now := time.Now()
+			traceVars.mu.Lock()
 			getConn := traceVars.getConn
-			traceVars.mu.RUnlock()
+			traceVars.gotConn = &now
+			traceVars.mu.Unlock()
 
 			if getConn != nil {
-				connTracking.setTotalLatency(fmt.Sprintf("%dms", time.Now().Sub(*getConn).Milliseconds()))
+				connTracking.setTotalLatency(fmt.Sprintf("%dms", now.Sub(*getConn).Milliseconds()))
 			}
 
 			connTracking.setReqConnInfo(&connInfo)

--- a/pkg/middleware/arm_error_collector.go
+++ b/pkg/middleware/arm_error_collector.go
@@ -53,8 +53,6 @@ type ResponseInfo struct {
 	ConnTracking  *HttpConnTracking
 }
 
-
-
 // ArmRequestMetricCollector is a interface that collectors need to implement.
 // TODO: use *policy.Request or *http.Request?
 type ArmRequestMetricCollector interface {
@@ -181,6 +179,7 @@ func parseTransportError(err error) *ArmError {
 }
 
 func addConnectionTracingToRequestContext(ctx context.Context, connTracking *HttpConnTracking) context.Context {
+	requestStart := time.Now()
 	// traceVars holds timing variables that need to be protected from concurrent access
 	// since HTTP trace callbacks run in separate goroutines
 	traceVars := &struct {
@@ -192,6 +191,9 @@ func addConnectionTracingToRequestContext(ctx context.Context, connTracking *Htt
 	}{}
 
 	trace := &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			connTracking.setFirstByteTimeInMs(time.Since(requestStart).Milliseconds())
+		},
 		GetConn: func(hostPort string) {
 			traceVars.mu.Lock()
 			defer traceVars.mu.Unlock()

--- a/pkg/middleware/http_conn_tracking.go
+++ b/pkg/middleware/http_conn_tracking.go
@@ -8,6 +8,9 @@ import (
 type HttpConnTracking struct {
 	// mu protects the values below
 	mu sync.RWMutex
+	// firstByteTimeInMs is the time from starting the request until the first
+	// response byte is received.
+	firstByteTimeInMs int64
 	// Thread-safe access to these fields is provided via getter methods.
 	// Direct field access may not be thread-safe during concurrent HTTP operations.
 	// Deprecated: Use GetTotalLatency() for thread-safe access
@@ -22,6 +25,14 @@ type HttpConnTracking struct {
 	Protocol string
 	// Deprecated: Use GetReqConnInfo() for thread-safe access
 	ReqConnInfo *httptrace.GotConnInfo
+}
+
+// GetFirstByteTimeInMs returns the time from starting the request until the
+// first response byte is received, in milliseconds, in a thread-safe manner.
+func (h *HttpConnTracking) GetFirstByteTimeInMs() int64 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.firstByteTimeInMs
 }
 
 // GetTotalLatency returns the total latency in a thread-safe manner
@@ -70,6 +81,12 @@ func (h *HttpConnTracking) setTotalLatency(latency string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.TotalLatency = latency
+}
+
+func (h *HttpConnTracking) setFirstByteTimeInMs(firstByteTimeInMs int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.firstByteTimeInMs = firstByteTimeInMs
 }
 
 func (h *HttpConnTracking) setDnsLatency(latency string) {

--- a/pkg/middleware/http_conn_tracking.go
+++ b/pkg/middleware/http_conn_tracking.go
@@ -8,8 +8,8 @@ import (
 type HttpConnTracking struct {
 	// mu protects the values below
 	mu sync.RWMutex
-	// firstByteTimeInMs is the time from starting the request until the first
-	// response byte is received.
+	// firstByteTimeInMs is the time from connection acquisition until the first
+	// response byte is received, in milliseconds.
 	firstByteTimeInMs int64
 	// Thread-safe access to these fields is provided via getter methods.
 	// Direct field access may not be thread-safe during concurrent HTTP operations.
@@ -27,7 +27,7 @@ type HttpConnTracking struct {
 	ReqConnInfo *httptrace.GotConnInfo
 }
 
-// GetFirstByteTimeInMs returns the time from starting the request until the
+// GetFirstByteTimeInMs returns the time from connection acquisition until the
 // first response byte is received, in milliseconds, in a thread-safe manner.
 func (h *HttpConnTracking) GetFirstByteTimeInMs() int64 {
 	h.mu.RLock()

--- a/pkg/middleware/http_conn_tracking_test.go
+++ b/pkg/middleware/http_conn_tracking_test.go
@@ -112,6 +112,20 @@ func Test_httpConnTrackingFirstResponseByteRequiresConnection(t *testing.T) {
 	assert.Zero(t, connTracking.GetFirstByteTimeInMs())
 }
 
+func Test_httpConnTrackingFirstResponseByteAfterConnection(t *testing.T) {
+	t.Parallel()
+
+	connTracking := new(HttpConnTracking)
+	ctx := addConnectionTracingToRequestContext(context.Background(), connTracking)
+	trace := httptrace.ContextClientTrace(ctx)
+
+	trace.GotConn(httptrace.GotConnInfo{})
+	time.Sleep(10 * time.Millisecond)
+	trace.GotFirstResponseByte()
+
+	assert.GreaterOrEqual(t, connTracking.GetFirstByteTimeInMs(), int64(10))
+}
+
 // BenchmarkHttpConnTracking benchmarks the performance of HttpConnTracking
 // with real HTTP requests to validate the performance impact of synchronization.
 //

--- a/pkg/middleware/http_conn_tracking_test.go
+++ b/pkg/middleware/http_conn_tracking_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/http/httptrace"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -50,30 +51,53 @@ func Test_httpConnTracking(t *testing.T) {
 
 func Test_httpConnTrackingThreadSafety(t *testing.T) {
 	t.Parallel()
-	
+
 	// Test that getter methods provide thread-safe access
 	connTracking := new(HttpConnTracking)
-	
+
 	// Set some values using the internal setters to simulate HTTP trace callbacks
 	connTracking.setDnsLatency("10ms")
 	connTracking.setConnLatency("5ms")
 	connTracking.setTlsLatency("15ms")
 	connTracking.setTotalLatency("30ms")
 	connTracking.setProtocol("h2")
-	
+	connTracking.setFirstByteTimeInMs(42)
+
 	// Verify getter methods return the expected values
 	assert.Equal(t, "10ms", connTracking.GetDnsLatency())
 	assert.Equal(t, "5ms", connTracking.GetConnLatency())
 	assert.Equal(t, "15ms", connTracking.GetTlsLatency())
 	assert.Equal(t, "30ms", connTracking.GetTotalLatency())
 	assert.Equal(t, "h2", connTracking.GetProtocol())
-	
+	assert.Equal(t, int64(42), connTracking.GetFirstByteTimeInMs())
+
 	// Verify backward compatibility - direct field access still works
 	assert.Equal(t, "10ms", connTracking.DnsLatency)
 	assert.Equal(t, "5ms", connTracking.ConnLatency)
 	assert.Equal(t, "15ms", connTracking.TlsLatency)
 	assert.Equal(t, "30ms", connTracking.TotalLatency)
 	assert.Equal(t, "h2", connTracking.Protocol)
+}
+
+func Test_httpConnTrackingFirstResponseByte(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	connTracking := new(HttpConnTracking)
+	ctx := addConnectionTracingToRequestContext(context.Background(), connTracking)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	assert.NoError(t, err)
+
+	resp, err := server.Client().Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.GreaterOrEqual(t, connTracking.GetFirstByteTimeInMs(), int64(10))
 }
 
 // BenchmarkHttpConnTracking benchmarks the performance of HttpConnTracking
@@ -83,7 +107,7 @@ func Test_httpConnTrackingThreadSafety(t *testing.T) {
 // goos: linux
 // goarch: amd64
 // pkg: github.com/Azure/azure-sdk-for-go-extensions/pkg/middleware
-// cpu: AMD EPYC 7763 64-Core Processor                
+// cpu: AMD EPYC 7763 64-Core Processor
 // BenchmarkHttpConnTracking/WithGetterMethods-16         	     516	   2228617 ns/op	   92211 B/op	     984 allocs/op
 // BenchmarkHttpConnTracking/WithDirectFieldAccess-16     	     540	   2223993 ns/op	   92188 B/op	     984 allocs/op
 // BenchmarkHttpConnTracking/ConcurrentGetterAccess-16    	 5319430	       219.7 ns/op	       0 B/op	       0 allocs/op
@@ -103,19 +127,19 @@ func BenchmarkHttpConnTracking(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			connTracking := &HttpConnTracking{}
 			ctx := addConnectionTracingToRequestContext(context.Background(), connTracking)
-			
+
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
 			if err != nil {
 				b.Fatalf("failed to create request: %v", err)
 			}
-			
+
 			// Use the test server's client to avoid certificate errors
 			resp, err := server.Client().Do(req)
 			if err != nil {
 				b.Fatalf("request failed: %v", err)
 			}
 			resp.Body.Close()
-			
+
 			// Access connection tracking data using thread-safe getter methods
 			_ = connTracking.GetTotalLatency()
 			_ = connTracking.GetDnsLatency()
@@ -131,19 +155,19 @@ func BenchmarkHttpConnTracking(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			connTracking := &HttpConnTracking{}
 			ctx := addConnectionTracingToRequestContext(context.Background(), connTracking)
-			
+
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
 			if err != nil {
 				b.Fatalf("failed to create request: %v", err)
 			}
-			
+
 			// Use the test server's client to avoid certificate errors
 			resp, err := server.Client().Do(req)
 			if err != nil {
 				b.Fatalf("request failed: %v", err)
 			}
 			resp.Body.Close()
-			
+
 			// Access connection tracking data using direct field access (may not be thread-safe)
 			_ = connTracking.TotalLatency
 			_ = connTracking.DnsLatency
@@ -202,7 +226,7 @@ func BenchmarkHttpConnTracking(b *testing.B) {
 
 	b.Run("MutexOverhead", func(b *testing.B) {
 		connTracking := &HttpConnTracking{}
-		
+
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			// Measure just the mutex overhead by doing lock/unlock cycles

--- a/pkg/middleware/http_conn_tracking_test.go
+++ b/pkg/middleware/http_conn_tracking_test.go
@@ -100,6 +100,18 @@ func Test_httpConnTrackingFirstResponseByte(t *testing.T) {
 	assert.GreaterOrEqual(t, connTracking.GetFirstByteTimeInMs(), int64(10))
 }
 
+func Test_httpConnTrackingFirstResponseByteRequiresConnection(t *testing.T) {
+	t.Parallel()
+
+	connTracking := new(HttpConnTracking)
+	ctx := addConnectionTracingToRequestContext(context.Background(), connTracking)
+	trace := httptrace.ContextClientTrace(ctx)
+
+	trace.GotFirstResponseByte()
+
+	assert.Zero(t, connTracking.GetFirstByteTimeInMs())
+}
+
 // BenchmarkHttpConnTracking benchmarks the performance of HttpConnTracking
 // with real HTTP requests to validate the performance impact of synchronization.
 //


### PR DESCRIPTION
## Summary
- add a `GotFirstResponseByte` HTTP trace callback
- track first-response-byte time in milliseconds on `HttpConnTracking`
- add thread-safe getter/setter coverage and an HTTP callback test

## Testing
- `go test ./pkg/middleware`
- `go test -race ./pkg/middleware`